### PR TITLE
Correction of terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## <a name="microsoft-open-source-code-of-conduct"></a>Código de Conduta de Software Livre da Microsoft
+## <a name="microsoft-open-source-code-of-conduct"></a>Código de Conduta de Open Source da Microsoft
 
 Este projeto adotou o [Código de Conduta Microsoft Open Source](https://opensource.microsoft.com/codeofconduct/).
 Para obter mais informações, confira as [Perguntas frequentes sobre o código de conduta](https://opensource.microsoft.com/codeofconduct/faq/) ou entre em contato com [opencode@microsoft.com](mailto:opencode@microsoft.com) para enviar outras perguntas ou comentários.


### PR DESCRIPTION
The code of conduct main, in english, mentioned Open Source and not Free/Open Software. Another possible localization is "código aberto", but you can use "open source", because it's ww term.