### PR TITLE
Improving pt-br translation

### DIFF
--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -1,6 +1,6 @@
 ---
-title: Configurar ambientes de preparo
-description: Saiba como implantar aplicativos em um slot que não seja de produção e o AutoSwap para produção. Aumente a confiabilidade e elimine o tempo de inatividade do aplicativo de implantações.
+title: Configurar ambientes de staging
+description: Saiba como implantar aplicativos em um slot não produtivo e fazer o auto swap para produção. Aumente a confiabilidade e acabe com o downtime ao fazer deploys.
 ms.assetid: e224fc4f-800d-469a-8d6a-72bcde612450
 ms.topic: article
 ms.date: 04/30/2020
@@ -12,227 +12,227 @@ ms.contentlocale: pt-BR
 ms.lasthandoff: 10/17/2020
 ms.locfileid: "92150331"
 ---
-# <a name="set-up-staging-environments-in-azure-app-service"></a>Configurar ambientes de preparo no Serviço de Aplicativo do Azure
+# <a name="set-up-staging-environments-in-azure-app-service"></a>Configurar ambientes de staging no Azure App Service
 <a name="Overview"></a>
 
-Ao implantar seu aplicativo Web, aplicativo Web no Linux, back-end móvel ou aplicativo de API para [Azure app serviço](./overview.md), você pode usar um slot de implantação separado em vez do slot de produção padrão quando estiver executando na camada de plano do serviço de aplicativo **padrão**, **Premium**ou **isolado** . Os slots de implantação são aplicativos ao vivo com seus próprios nomes de host. Os elementos de configurações e conteúdo de aplicativo podem ser trocados entre dois slots de implantação, incluindo o slot de produção. 
+Ao implantar seu aplicativo web, aplicativo web no Linux, back-end para mobile ou aplicativo de API no [Azure App Service](./overview.md), você pode usar um slot de implantação apartado, em vez do slot padrão de produção ao utilizar o plano **Standard**, **Premium** ou **Isolado** do Serviço de Aplicativo. Os slots de implantação são aplicativos funcionais que possuem seus próprios host names. Os elementos de configurações e o conteúdo dos aplicativos podem ser alternados entre dois slots de implantação, incluindo o slot de produção.
 
-A implantação do aplicativo em um slot de não produção traz os seguintes benefícios:
+A implantação do aplicativo em um slot não produtivo traz os seguintes benefícios:
 
-* É possível validar as alterações no aplicativo em um slot de implantação de preparo antes de permutá-lo pelo slot de produção.
-* Implantar um aplicativo em um slot primeiro e alterná-lo para produção garantem que todas as instâncias do slot estejam aquecidas antes de alterná-lo para produção. Isso elimina o tempo de inatividade quando você for implantar seu aplicativo. O redirecionamento de tráfego é contínuo, e nenhuma solicitação é removida devido a operações de alternância. Você pode automatizar todo esse fluxo de trabalho configurando a [troca automática](#Auto-Swap) quando a validação de pré-atualização não for necessária.
-* Após a troca, o slot com o aplicativo de preparo anterior terá o aplicativo de produção anterior. Se as alterações alternadas para o slot de produção não correspondem às suas expectativas, você pode realizar a mesma alternância imediatamente para ter o "último site válido conhecido" de volta.
+* É possível validar as alterações no aplicativo em um slot de implantação de staging antes de fazer o swapp com o slot de produção.
+* Implantar um aplicativo primeiro em um slot e depois promovê-lo para produção garante que todas as instâncias do slot estejam aquecidas antes de promovê-lo para produção. Isso elimina o downtime quando você for fazer deploy do seu aplicativo. O redirecionamento de tráfego é ininterrupto, e nenhuma request é perdida devido a operação de swap. Você pode automatizar todo esse fluxo configurando o [auto swap](#Auto-Swap) quando uma validação antes de realizar o swap não for necessária.
+* Após o swap, o slot que anteriormente continha o aplicativo de staging passará então a conter o aplicativo de produção. Se as alterações promovidas para o slot de produção não corresponderem às suas expectativas, você poderá realizar a mesma troca imediatamente para obter a "última versão funcional do site" de volta.
 
-Cada tipo de plano do Serviço de Aplicativo dá suporte a um número diferente de slots de implantação. Não há nenhum custo adicional para usar os slots de implantação. Para descobrir o número de Slots com suporte na camada do aplicativo, consulte [limites do serviço de aplicativo](../azure-resource-manager/management/azure-subscription-service-limits.md#app-service-limits). 
+Cada tipo de plano do Serviço de Aplicativo dá suporte a um número diferente de slots de implantação. Não há nenhum custo adicional para usar os slots de implantação. Para descobrir a quantidade de slots que a camada do seu aplicativo suporta, consulte [limites do Serviço de Aplicativo](../azure-resource-manager/management/azure-subscription-service-limits.md#app-service-limits).
 
-Para dimensionar seu aplicativo para uma camada diferente, verifique se a camada de destino dá suporte ao número de slots que seu aplicativo já usa. Por exemplo, se seu aplicativo tiver mais de cinco slots, você não poderá dimensioná-lo para a camada **Standard** , pois a camada **Standard** oferece suporte a apenas cinco slots de implantação. 
+Para escalar seu aplicativo para uma camada diferente, verifique se a camada desejada dá suporte ao número de slots que seu aplicativo já utiliza. Por exemplo, se seu aplicativo tiver mais de cinco slots, você não poderá dimensioná-lo para a camada **Standard**, pois a camada **Standard** oferece suporte a apenas cinco slots de implantação.
 
 <a name="Add"></a>
 
 ## <a name="add-a-slot"></a>Adicionar um slot
-O aplicativo deve estar em execução na camada **Standard**, **Premium**ou **Isolated** para que você habilite vários slots de implantação.
+O aplicativo deve estar em execução na camada **Standard**, **Premium** ou **Isolado** para que você possa habilitar multiplos slots de implantação.
 
 
-1. na [portal do Azure](https://portal.azure.com/), procure e selecione serviços de **aplicativos** e selecione seu aplicativo. 
+1. no [Portal do Azure](https://portal.azure.com/), pesquise e selecione **Serviços de Aplicativos** e selecione o seu aplicativo.
    
-    ![Pesquisar serviços de aplicativos](./media/web-sites-staged-publishing/search-for-app-services.png)
+    ![Pesquisar no Serviço de Aplicativo](./media/web-sites-staged-publishing/search-for-app-services.png)
    
 
-2. No painel esquerdo, selecione **Slots de implantação**  >  **Adicionar slot**.
+2. No painel do lado esquerdo, selecione **Slots de implantação**  >  **Adicionar Slot**.
    
     ![Adicionar um novo slot de implantação](./media/web-sites-staged-publishing/QGAddNewDeploymentSlot.png)
    
    > [!NOTE]
-   > Se o aplicativo ainda não estiver na camada **Standard**, **Premium**ou **Isolated** , você receberá uma mensagem que indica as camadas com suporte para habilitar a publicação em etapas. Neste ponto, você tem a opção de selecionar **Atualizar** e ir para a guia **escala** do seu aplicativo antes de continuar.
+   > Se o aplicativo ainda não estiver na camada **Standard**, **Premium** ou **Isolado**, você receberá uma mensagem indicando quais camadas dão suporte para habilitar a publicação em stage. Nesse momento, você terá a opção de selecionar **Atualizar** e ir para a guia **Escalar** do seu aplicativo, antes de continuar.
    > 
 
-3. Na caixa de diálogo **Adicionar um slot** , dê um nome ao slot e selecione se deseja clonar uma configuração de aplicativo de outro slot de implantação. Selecione **Adicionar** para continuar.
+3. Na caixa de diálogo **Adicionar um slot**, dê um nome ao slot e selecione se deseja clonar uma configuração de aplicativo de outro slot de implantação. Selecione **Adicionar** para continuar.
    
     ![Fonte de configuração](./media/web-sites-staged-publishing/ConfigurationSource1.png)
    
-    Você pode clonar uma configuração de qualquer slot existente. As configurações que podem ser clonadas incluem configurações de aplicativo, cadeias de conexão, versões da estrutura de linguagem, soquetes da Web, versão HTTP e número de bits da plataforma.
+    Você pode clonar uma configuração de qualquer outro slot existente. As configurações que podem ser clonadas incluem configurações de aplicativo, strings de conexão, versões do framework da linguagem, web sockets, versão do HTTP e número de bits da plataforma.
 
-4. Depois que o slot for adicionado, selecione **fechar** para fechar a caixa de diálogo. O novo slot agora é mostrado na página **Slots de implantação** . Por padrão, o **tráfego%** é definido como 0 para o novo slot, com todo o tráfego do cliente roteado para o slot de produção.
+4. Depois que o slot for adicionado, selecione **Fechar** para fechar a caixa de diálogo. O novo slot agora é exibido na página **Slots de implantação**. Por padrão, o **Tráfego %** é definido como 0 para o novo slot, com todo o tráfego do cliente sendo roteado para o slot de produção.
 
 5. Selecione o novo slot de implantação para abrir a página de recursos do slot.
    
     ![Título do slot de implantação](./media/web-sites-staged-publishing/StagingTitle.png)
 
-    O slot de preparo tem uma página de gerenciamento como qualquer outro aplicativo do Serviço de Aplicativo. É possível alterar a configuração do slot. Para lembrá-lo de que você está exibindo o slot de implantação, o nome do aplicativo é mostrado como **\<app-name>/\<slot-name>** e o tipo de aplicativo é **serviço de aplicativo (slot)**. Você também pode ver o slot como um aplicativo separado em seu grupo de recursos, com as mesmas designações.
+    O slot de staging tem uma página de gerenciamento como qualquer outro aplicativo do Serviço de Aplicativo. É possível alterar a configuração do slot. Para lembrá-lo de que você está visualizando o slot de implantação, o nome do aplicativo é exibido como **\<nome-do-aplicativo>/\<nome-do-slot>** e o tipo do aplicativo é **Serviço de Aplicativo (Slot)**. Você também pode ver o slot como um aplicativo apartado em seu grupo de recursos, com as mesmas designações.
 
-6. Selecione a URL do aplicativo na página de recursos do slot. O slot de implantação tem seu próprio nome de host e também é um aplicativo ativo. Para limitar o acesso público ao slot de implantação, consulte [Azure app restrições de IP do serviço](app-service-ip-restrictions.md).
+6. Selecione a URL do aplicativo na página de recursos do slot. O slot de implantação possui seu próprio host name e também é um aplicativo funcional. Para limitar acesso público ao slot de implantação, consulte [Restrições de IP no Serviço de Aplicativo do Azure](app-service-ip-restrictions.md).
 
-O novo slot de implantação não tem nenhum conteúdo, mesmo se as configurações são clonadas de outro slot. Por exemplo, você pode [publicar neste slot com o Git](./deploy-local-git.md). É possível fazer uma implantação no slot de outro branch do repositório ou de outro repositório.
+O novo slot de implantação não possui nenhum conteúdo, mesmo que você clone as configurações de outro slot. Por exemplo, você pode [publicar nesse slot a partir do Git](./deploy-local-git.md). Você pode fazer deploy no slot a partir de outra branch ou a partir de outro repositório.
 
 <a name="AboutConfiguration"></a>
 
-## <a name="what-happens-during-a-swap"></a>O que acontece durante uma permuta
+## <a name="what-happens-during-a-swap"></a>O que acontece durante um swap
 
-### <a name="swap-operation-steps"></a>Etapas da operação de permuta
+### <a name="swap-operation-steps"></a>Etapas da operação de swap
 
-Quando você troca dois slots (geralmente de um slot de preparo no slot de produção), o serviço de aplicativo faz o seguinte para garantir que o slot de destino não experimente tempo de inatividade:
+Quando você faz o swap entre dois slots (geralmente de um slot de staging para o slot de produção), o Serviço de Aplicativo faz o seguinte para garantir que o slot de destino não fique indisponível:
 
-1. Aplique as seguintes configurações do slot de destino (por exemplo, o slot de produção) a todas as instâncias do slot de origem: 
-    - Configurações do aplicativo e cadeias [de conexão específicas do slot](#which-settings-are-swapped) , se aplicável.
-    - Configurações de [implantação contínua](deploy-continuous-deployment.md) , se habilitadas.
-    - Configurações de [autenticação do serviço de aplicativo](overview-authentication-authorization.md) , se habilitadas.
+1. Aplica as seguintes configurações do slot de destino (por exemplo, o slot de produção) em todas as instâncias do slot de origem:
+    - [Configurações de aplicativo específicas do slot](#which-settings-are-swapped) e strings de conexão, se aplicável.
+    - Configurações de [continuous deployment](deploy-continuous-deployment.md), se habilitado.
+    - Configurações de [autenticação do Serviço de Aplicativo](overview-authentication-authorization.md), se habilitado.
     
-    Qualquer um desses casos disparará todas as instâncias no slot de origem para reiniciar. Durante a [troca com visualização](#Multi-Phase), isso marca o final da primeira fase. A operação de permuta está pausada e você pode validar que o slot de origem funciona corretamente com as configurações do slot de destino.
+    Em qualquer dos casos todas as instâncias no slot de origem serão reiniciadas. Durante a [troca com pré-visualização](#Multi-Phase), isso marca o final da primeira fase. A operação de swap será pausada e você poderá validar se o slot de origem funciona corretamente com as configurações do slot de destino.
 
-1. Aguarde até que cada instância no slot de origem conclua sua reinicialização. Se alguma instância não for reiniciada, a operação de permuta reverterá todas as alterações no slot de origem e interromperá a operação.
+1. Aguarda até que cada uma das instâncias no slot de origem conclua a sua reinicialização. Se alguma instância falhar ao reiniciar, a operação de swap reverterá todas as alterações no slot de origem e interromperá a operação.
 
-1. Se o [cache local](overview-local-cache.md) estiver habilitado, dispare a inicialização do cache local fazendo uma solicitação HTTP para a raiz do aplicativo ("/") em cada instância do slot de origem. Aguarde até que cada instância retorne qualquer resposta HTTP. A inicialização do cache local causa outra reinicialização em cada instância.
+1. Se o [cache local](overview-local-cache.md) estiver habilitado, dispara a inicialização do cache local fazendo uma requisição HTTP na raiz da aplicação ("/") em cada uma das instâncias do slot de origem. Aguarda até que cada uma das instâncias retorne alguma resposta HTTP. A inicialização do cache local causa outra reinicialização em cada uma das instâncias.
 
-1. Se a [troca automática](#Auto-Swap) estiver habilitada com a inicialização [personalizada](#Warm-up)do [aplicativo](/iis/get-started/whats-new-in-iis-8/iis-80-application-initialization) de disparo, fazendo uma solicitação HTTP para a raiz do aplicativo ("/") em cada instância do slot de origem.
+1. Se o [auto swap](#Auto-Swap) estiver habilitado com o [aquecimento personalizado](#Warm-up), dispara a [Inicialização do Aplicativo](/iis/get-started/whats-new-in-iis-8/iis-80-application-initialization) fazendo uma requisição HTTP na raiz da aplicação ("/") em cada uma das instâncias do slot de origem.
 
-    Se `applicationInitialization` não for especificado, dispare uma solicitação HTTP para a raiz do aplicativo do slot de origem em cada instância. 
+    Se `applicationInitialization` não for especificado, dispara uma requisição HTTP na raiz da aplicação do slot de origem em cada uma das instâncias.
     
-    Se uma instância retornar qualquer resposta HTTP, ela será considerada como ativada.
+    Se uma instância retornar alguma resposta HTTP, ela será considerada como estando aquecida.
 
-1. Se todas as instâncias no slot de origem forem ativadas com êxito, troque os dois slots alternando as regras de roteamento para os dois slots. Após essa etapa, o slot de destino (por exemplo, o slot de produção) tem o aplicativo que foi anteriormente ativado no slot de origem.
+1. Se todas as instâncias no slot de origem forem aquecidas com sucesso, troca os dois slots alternando as regras de roteamento para os dois slots. Após essa etapa, o slot de destino (por exemplo, o slot de produção) irá conter o aplicativo que foi anteriormente aquecido no slot de origem.
 
-1. Agora que o slot de origem tem o aplicativo de pré-permuta anteriormente no slot de destino, execute a mesma operação aplicando todas as configurações e reiniciando as instâncias.
+1. Agora que o slot de origem contém o aplicativo pré-swap que estava anteriormente no slot de destino, executa a mesma operação aplicando todas as configurações e reiniciando as instâncias.
 
-Em qualquer ponto da operação de permuta, todo o trabalho de inicializar os aplicativos trocados ocorre no slot de origem. O slot de destino permanece online enquanto o slot de origem está sendo preparado e ativado, independentemente de onde a troca tenha êxito ou falhe. Para trocar um slot de preparo pelo slot de produção, verifique se o slot de produção é sempre o slot de destino. Dessa forma, a operação de permuta não afeta seu aplicativo de produção.
+Em qualquer ponto da operação de swap, todo o trabalho de inicializar os aplicativos trocados ocorre no slot de origem. O slot de destino permanece online enquanto o slot de origem está sendo preparado e aquecido, independentemente de onde a troca tenha êxito ou falhe. Para trocar um slot de staging pelo slot de produção, certifique-se de que o slot de produção é sempre o slot de destino. Dessa forma, a operação de swap não afeta o seu aplicativo de produção.
 
 ### <a name="which-settings-are-swapped"></a>Quais configurações são trocadas?
 
 [!INCLUDE [app-service-deployment-slots-settings](../../includes/app-service-deployment-slots-settings.md)]
 
-Para configurar uma cadeia de conexão ou configuração de aplicativo para se conectar a um slot específico (não trocado), vá para a página de **configuração** desse slot. Adicione ou edite uma configuração e, em seguida, selecione **configuração do slot de implantação**. Marcar essa caixa de seleção informa ao serviço de aplicativo que a configuração não é intercambiável. 
+Para configurar uma string de conexão ou configuração de aplicativo para se fixar a um slot específico (não trocado), vá para a página de **Configuração** deste slot. Adicione ou edite uma configuração e, em seguida, selecione **configuração do slot de implantação**. Marcar essa caixa de seleção informa ao Serviço de Aplicativo que a configuração não é intercambiável.
 
 ![Configuração do slot](./media/web-sites-staged-publishing/SlotSetting.png)
 
 <a name="Swap"></a>
 
-## <a name="swap-two-slots"></a>Alternar dois slots 
-Você pode alternar os slots de implantação na página de **Slots de implantação** do aplicativo e na página **visão geral** . Para obter detalhes técnicos sobre a troca de slot, consulte [o que acontece durante a permuta](#AboutConfiguration).
+## <a name="swap-two-slots"></a>Alternar dois slots
+Você pode alternar os slots de implantação na página de **Slots de implantação** do aplicativo e na página **Visão geral**. Para obter detalhes técnicos sobre o swap de slot, consulte [o que acontece durante um swap](#AboutConfiguration).
 
 > [!IMPORTANT]
-> Antes de trocar um aplicativo de um slot de implantação em produção, verifique se a produção é o slot de destino e se todas as configurações no slot de origem estão configuradas exatamente como você deseja tê-las em produção.
+> Antes de alternar um aplicativo de um slot de implantação para produção, certifique-se de que produção é o slot de destino e que todas as configurações no slot de origem estão configuradas exatamente como você deseja tê-las em produção.
 > 
 > 
 
-Para permutar slots de implantação:
+Para alternar slots de implantação:
 
-1. Vá para a página **Slots de implantação** do aplicativo e selecione **alternar**.
+1. Vá para a página **Slots de implantação** do aplicativo e selecione **Alternar**.
    
     ![Botão Alternar](./media/web-sites-staged-publishing/SwapButtonBar.png)
 
-    A caixa de diálogo **alternar** mostra as configurações nos slots de origem e destino selecionados que serão alterados.
+    A caixa de diálogo **Alternar** mostra as configurações nos slots de origem e destino selecionados, que serão alternados.
 
-2. Selecione os slots de **Origem** e de **Destino** desejados. Geralmente, o destino é o slot de produção. Além disso, selecione as guias **alterações de origem** e **alterações de destino** e verifique se as alterações de configuração são esperadas. Quando tiver terminado, você poderá trocar os slots imediatamente selecionando **alternar**.
+2. Selecione os slots de **Origem** e de **Destino** desejados. Geralmente, o destino é o slot de produção. Além disso, selecione as guias **Alterações de Origem** e **Alterações de Destino** e verifique se as alterações de configuração são esperadas. Quando tiver terminado, você poderá trocar os slots imediatamente selecionando **Alternar**.
 
     ![Troca completa](./media/web-sites-staged-publishing/SwapImmediately.png)
 
-    Para ver como o slot de destino seria executado com as novas configurações antes que a permuta realmente aconteça, não selecione **alternar**, mas siga as instruções em [alternar com visualização](#Multi-Phase).
+    Para ver como o slot de destino seria executado com as novas configurações antes que o swap realmente aconteça, não selecione **Alternar**, ao invés disso siga as instruções em [Swap com pré-visualização](#Multi-Phase).
 
-3. Quando tiver terminado, feche a caixa de diálogo selecionando **fechar**.
+3. Quando tiver terminado, feche a caixa de diálogo selecionando **Fechar**.
 
-Se você tiver problemas, consulte [solucionar problemas de trocas](#troubleshoot-swaps).
+Se você tiver algum problema, consulte [Solucionar problemas com swaps](#troubleshoot-swaps).
 
 <a name="Multi-Phase"></a>
 
-### <a name="swap-with-preview-multi-phase-swap"></a>Troca com visualização (troca de várias fases)
+### <a name="swap-with-preview-multi-phase-swap"></a>Swap com pré-visualização (swap de multiplas fases)
 
-Antes de trocar para produção como o slot de destino, valide se o aplicativo é executado com as configurações trocadas. O slot de origem também é ativado antes da conclusão da permuta, o que é desejável para aplicativos de missão crítica.
+Antes de trocar para produção como slot de destino, valide se o aplicativo funciona com as configurações alternadas. O slot de origem também é aquecido antes da conclusão do swap, o que é desejável para aplicativos de missão crítica.
 
-Quando você executa uma troca com visualização, o serviço de aplicativo executa a mesma [operação de permuta](#AboutConfiguration) , mas pausa após a primeira etapa. Em seguida, você pode verificar o resultado no slot de preparo antes de concluir a permuta. 
+Quando você executa uma troca com pré-visualização, o Serviço de Aplicativo executa a mesma [operação de swap](#AboutConfiguration), mas pausa após a primeira etapa. Em seguida, você pode verificar o resultado no slot de staging antes de concluir o swap.
 
-Se você cancelar a troca, o serviço de aplicativo reaplicará os elementos de configuração ao slot de origem.
+Se você cancelar a troca, o Serviço de Aplicativo reaplicará os elementos de configuração no slot de origem.
 
-Para alternar com a visualização:
+Para alternar com pré-visualização:
 
-1. Siga as etapas em [trocar slots de implantação](#Swap) , mas selecione **executar permuta com visualização**.
+1. Siga as etapas em [Alternar slots de implantação](#Swap), porem selecione **Executar swap com pré-visualização**.
 
-    ![Alternância com visualização](./media/web-sites-staged-publishing/SwapWithPreview.png)
+    ![Swap com pré-visualização](./media/web-sites-staged-publishing/SwapWithPreview.png)
 
-    A caixa de diálogo mostra como a configuração no slot de origem muda na fase 1 e como a origem e o slot de destino são alterados na fase 2.
+    A caixa de diálogo mostra como a configuração no slot de origem muda na fase 1, e como a origem e o slot de destino serão alterados na fase 2.
 
-2. Quando estiver pronto para iniciar a troca, selecione **Iniciar permuta**.
+2. Quando estiver pronto para iniciar a troca, selecione **Iniciar Swap**.
 
-    Quando a fase 1 for concluída, você será notificado na caixa de diálogo. Visualize a troca no slot de origem acessando `https://<app_name>-<source-slot-name>.azurewebsites.net` . 
+    Quando a fase 1 for concluída, você será notificado na caixa de diálogo. Visualize a troca no slot de origem acessando `https://<nome_do_aplicativo>-<nome-slot-origem>.azurewebsites.net`.
 
-3. Quando estiver pronto para concluir a permuta pendente, selecione **concluir permuta** na **ação de permuta** e selecione **concluir permuta**.
+3. Quando estiver pronto para concluir o swap que esta pendente, selecione **Concluir swap** em **Ação de swap** e selecione **Concluir swap**.
 
-    Para cancelar uma permuta pendente, selecione **Cancelar permuta** em vez disso.
+    Para cancelar um swap pendente, ao invés disso selecione **Cancelar swap**.
 
-4. Quando tiver terminado, feche a caixa de diálogo selecionando **fechar**.
+4. Quando tiver terminado, feche a caixa de diálogo selecionando **Fechar**.
 
-Se você tiver problemas, consulte [solucionar problemas de trocas](#troubleshoot-swaps).
+Se você tiver algum problema, consulte [Solucionar problemas com swaps](#troubleshoot-swaps).
 
-Para automatizar uma troca de várias fases, consulte [automatizar com o PowerShell](#automate-with-powershell).
+Para automatizar um swap de multiplas fases, consulte [Automatizar com PowerShell](#automate-with-powershell).
 
 <a name="Rollback"></a>
 
-## <a name="roll-back-a-swap"></a>Reverter uma permuta
-Se ocorrerem erros no slot de destino (por exemplo, o slot de produção) após uma alternância de slot, restaure os slots para seus estados de pré-alternância alternando os mesmos dois slots imediatamente.
+## <a name="roll-back-a-swap"></a>Reverter um swap
+Se ocorrerem erros no slot de destino (por exemplo, o slot de produção) após uma troca de slot, restaure os slots para seus estados pré-swap alternando os mesmos dois slots imediatamente.
 
 <a name="Auto-Swap"></a>
 
-## <a name="configure-auto-swap"></a>Configurar a troca automática
+## <a name="configure-auto-swap"></a>Configurando o auto swap
 
 > [!NOTE]
-> A troca automática não tem suporte em aplicativos Web no Linux.
+> Não ha suporte para a troca automática em aplicativos Web no Linux.
 
-A troca automática simplifica os cenários de DevOps do Azure em que você deseja implantar seu aplicativo continuamente com inícios inativos sem interrupção e sem tempo de inatividade para clientes do aplicativo. Quando a troca automática está habilitada de um slot para produção, sempre que você envia por push as alterações de código para esse slot, [o serviço de aplicativo troca automaticamente o aplicativo em produção](#swap-operation-steps) depois que ele é ativado no slot de origem.
+A troca automática simplifica cenários no Azure DevOps onde você deseje implantar seu aplicativo de forma continua sem interrupções e sem downtime para os consumidores do aplicativo. Quando a troca automática de um slot para produção está habilitada, toda vez que você enviar alterações de código por push para este slot, o Serviço de Aplicativo [alterna automaticamente o aplicativo para produção](#swap-operation-steps) depois que ele for aquecido no slot de origem.
 
    > [!NOTE]
-   > Antes de configurar a troca automática para o slot de produção, considere testar a troca automática em um slot de destino de não produção.
+   > Antes de configurar a troca automática para o slot de produção, considere testar a troca automática em um slot de destino não produtivo.
    > 
 
 Para configurar a troca automática:
 
-1. Vá para a página de recursos do aplicativo. Selecione **Slots de implantação**  >  *\<desired source slot>*  >  **configuração**  >  **geral configurações**.
+1. Vá para a página de recursos do aplicativo. Selecione **Slots de implantação** > *\<slot de origem desejado>* > **Configuração** > **Configurações gerais**.
    
-2. Para a **troca automática habilitada**, selecione **ativado**. Em seguida, selecione o slot de destino desejado para o **slot de implantação de permuta automática**e selecione **salvar** na barra de comandos. 
+2. Em **Troca automática habilitada**, selecione **Ativado**. Em seguida, selecione o slot de destino desejado para o **Slot de implantação de troca automática** e selecione **Salvar** na barra de comandos.
    
     ![Seleções para configurar a troca automática](./media/web-sites-staged-publishing/AutoSwap02.png)
 
 3. Execute um push de código para o slot de origem. A troca automática ocorre após um curto período de tempo e a atualização é refletida na URL do slot de destino.
 
-Se você tiver problemas, consulte [solucionar problemas de trocas](#troubleshoot-swaps).
+Se você tiver algum problema, consulte [Solucionar problemas com swaps](#troubleshoot-swaps).
 
 <a name="Warm-up"></a>
 
 ## <a name="specify-custom-warm-up"></a>Especificar aquecimento personalizado
 
-Alguns aplicativos podem exigir ações de aquecimento personalizadas antes da troca. O `applicationInitialization` elemento de configuração no web.config permite que você especifique ações de inicialização personalizadas. A [operação de permuta](#AboutConfiguration) aguarda que esse aquecimento personalizado seja concluído antes de alternar com o slot de destino. Aqui está um fragmento de web.config de exemplo.
+Alguns aplicativos podem exigir ações personalizadas de aquecimento antes do swap. O elemento de configuração `applicationInitialization` no web.config permite que você especifique ações de inicialização personalizadas. A [operação de swap](#AboutConfiguration) aguarda que esse aquecimento personalizado seja concluído antes de alternar com o slot de destino. Aqui está um trecho de web.config como exemplo.
 
 ```xml
 <system.webServer>
     <applicationInitialization>
-        <add initializationPage="/" hostName="[app hostname]" />
-        <add initializationPage="/Home/About" hostName="[app hostname]" />
+        <add initializationPage="/" hostName="[host name do aplicativo]" />
+        <add initializationPage="/Home/About" hostName="[host name do aplicativo]" />
     </applicationInitialization>
 </system.webServer>
 ```
 
-Para obter mais informações sobre como personalizar o `applicationInitialization` elemento, consulte [falhas de permuta de slot de implantação mais comuns e como corrigi-los](https://ruslany.net/2017/11/most-common-deployment-slot-swap-failures-and-how-to-fix-them/).
+Para obter mais informações sobre como personalizar o elemento `applicationInitialization`, consulte [Falhas de swap de slot de implantação mais comuns e como corrigi-las](https://ruslany.net/2017/11/most-common-deployment-slot-swap-failures-and-how-to-fix-them/).
 
-Você também pode personalizar o comportamento de aquecimento com uma ou ambas as seguintes configurações de [aplicativo](configure-common.md):
+Você também pode personalizar o comportamento de aquecimento com uma, ou ambas, as seguintes [configurações de aplicativo](configure-common.md):
 
-- `WEBSITE_SWAP_WARMUP_PING_PATH`: O caminho para o ping para aquecimento do seu site. Adicione essa configuração de aplicativo especificando um caminho personalizado que começa com uma barra (“/”) como o valor. Um exemplo é `/statuscheck`. O valor padrão é `/`. 
-- `WEBSITE_SWAP_WARMUP_PING_STATUSES`: Códigos de resposta HTTP válidos para a operação de aquecimento. Adicione essa configuração de aplicativo com uma lista separada por vírgulas dos códigos HTTP. Um exemplo é `200,202` . Se o código de status retornado não estiver na lista, as operações aquecimento e swap serão interrompidas. Por padrão, todos os códigos de resposta são válidos.
+- `WEBSITE_SWAP_WARMUP_PING_PATH`: O caminho para o ping de aquecimento do seu site. Adicione essa configuração de aplicativo especificando um caminho personalizado que começe com uma barra (“/”) como valor. Um exemplo é `/statuscheck`. O valor padrão é `/`.
+- `WEBSITE_SWAP_WARMUP_PING_STATUSES`: Códigos de resposta HTTP válidos para a operação de aquecimento. Adicione essa configuração de aplicativo com uma lista de códigos HTTP separada por vírgulas. Um exemplo é `200,202`. Se o código de status retornado não estiver na lista, as operações aquecimento e swap serão interrompidas. Por padrão, todos os códigos de resposta são válidos.
 
 > [!NOTE]
-> O `<applicationInitialization>` elemento de configuração faz parte de cada inicialização de aplicativo, enquanto as duas configurações de aplicativo de comportamento de aquecimento se aplicam somente a trocas de slot.
+> O elemento de configuração `<applicationInitialization>` faz parte de cada inicialização de aplicativo, enquanto as duas configurações de comportamento de aquecimento do aplicativo se aplicam somente a trocas de slot.
 
-Se você tiver problemas, consulte [solucionar problemas de trocas](#troubleshoot-swaps).
+Se você tiver algum problema, consulte [Solucionar problemas com swaps](#troubleshoot-swaps).
 
 ## <a name="monitor-a-swap"></a>Monitorar uma troca
 
-Se a [operação de permuta](#AboutConfiguration) levar muito tempo para ser concluída, você poderá obter informações sobre a operação de permuta no [log de atividades](../azure-monitor/platform/platform-logs-overview.md).
+Se a [operação de swap](#AboutConfiguration) levar muito tempo para ser concluída, você poderá obter informações sobre a operação de swap nos [logs de atividades](../azure-monitor/platform/platform-logs-overview.md).
 
-Na página de recursos do aplicativo no portal, no painel esquerdo, selecione log de **atividades**.
+Na página de recursos do seu aplicativo no portal, no painel esquerdo, selecione **Logs de atividades**.
 
-Uma operação de troca é exibida na consulta de log como `Swap Web App Slots`. Você pode expandi-lo e selecionar uma das suboperações ou um dos erros para ver os detalhes.
+Uma operação de troca é exibida na consulta de log como `Swap Web App Slots`. Você pode expandi-la e selecionar uma das suboperações ou um dos erros para ver os detalhes.
 
 ## <a name="route-traffic"></a>Rotear o tráfego
 
-Por padrão, todas as solicitações de cliente para a URL de produção do aplicativo (`http://<app_name>.azurewebsites.net`) são roteadas para o slot de produção. É possível rotear uma parte do tráfego para outro slot. Esse recurso é útil se você precisa de comentários do usuário para uma nova atualização, mas não está pronto para liberá-la para produção.
+Por padrão, todas as requisições de cliente para a URL de produção do aplicativo (`http://<nome_do_aplicativo>.azurewebsites.net`) são roteadas para o slot de produção. É possível rotear uma parte do tráfego para outro slot. Esse recurso é útil se você precisa de feedback do usuário referente a uma nova atualização, mas você não está pronto para liberá-la em produção.
 
-### <a name="route-production-traffic-automatically"></a>Rotear o tráfego de produção automaticamente
+### <a name="route-production-traffic-automatically"></a>Rotear tráfego de produção automaticamente
 
 Para rotear o tráfego de produção automaticamente:
 
@@ -242,39 +242,39 @@ Para rotear o tráfego de produção automaticamente:
 
     ![Definindo um percentual de tráfego](./media/web-sites-staged-publishing/RouteTraffic.png)
 
-Depois que a configuração é salva, a porcentagem especificada de clientes é roteada aleatoriamente para o slot de não produção. 
+Depois que a configuração for salva, a porcentagem especificada de clientes é roteada de forma aleatória para o slot não produtivo.
 
-Depois que um cliente é roteado automaticamente para um slot específico, ele é "fixado" a esse slot durante a vida útil dessa sessão de cliente. No navegador do cliente, você pode ver em qual slot a sessão está fixada observando o cookie `x-ms-routing-name` nos cabeçalhos HTTP. Uma solicitação roteada para o slot "de preparo" tem o cookie `x-ms-routing-name=staging`. Uma solicitação roteada para o slot de produção tem o cookie `x-ms-routing-name=self`.
+Depois que um cliente é roteado automaticamente para um slot específico, ele é "fixado" a esse slot durante a vida útil da sessão do cliente. No navegador do cliente, você pode ver em qual slot a sessão dele está fixada observando o cookie `x-ms-routing-name` nos cabeçalhos HTTP. Uma requisição roteada para o slot de "staging" irá conter o cookie `x-ms-routing-name=staging`. Uma requisição roteada para o slot de produção irá conter o cookie `x-ms-routing-name=self`.
 
    > [!NOTE]
-   > Ao lado do portal do Azure, você também pode usar o [`az webapp traffic-routing set`](/cli/azure/webapp/traffic-routing#az-webapp-traffic-routing-set) comando na CLI do Azure para definir as porcentagens de roteamento de ferramentas de CI/CD, como pipelines DevOps ou outros sistemas de automação.
+   > Além do Portal do Azure, você também pode usar o comando [`az webapp traffic-routing set`](/cli/azure/webapp/traffic-routing#az-webapp-traffic-routing-set) na CLI do Azure para definir as porcentagens de roteamento a partir de ferramentas de CI/CD, como pipelines DevOps ou outros sistemas de automação.
    > 
 
-### <a name="route-production-traffic-manually"></a>Rotear o tráfego de produção manualmente
+### <a name="route-production-traffic-manually"></a>Rotear tráfego de produção manualmente
 
-Além do roteamento de tráfego automático, o Serviço de Aplicativo pode rotear solicitações para um slot específico. Isso é útil quando você deseja que os usuários possam aceitar ou recusar seu aplicativo beta. Para rotear o tráfego de produção manualmente, use o parâmetro de consulta `x-ms-routing-name`.
+Além do roteamento de tráfego automático, o Serviço de Aplicativo pode rotear requisições para um slot específico. Isso é útil quando você deseja que os usuários possam aceitar ou recusar seu aplicativo beta. Para rotear o tráfego de produção manualmente, use o parâmetro de query string `x-ms-routing-name`.
 
-Para permitir que os usuários recusem seu aplicativo beta, por exemplo, você pode colocar esse link em sua página da Web:
+Para permitir que os usuários recusem seu aplicativo beta, por exemplo, você pode colocar esse link em sua página web:
 
 ```html
-<a href="<webappname>.azurewebsites.net/?x-ms-routing-name=self">Go back to production app</a>
+<a href="<nomedoaplicativoweb>.azurewebsites.net/?x-ms-routing-name=self">Go back to production app</a>
 ```
 
-A cadeia de caracteres `x-ms-routing-name=self` especifica o local de produção. Depois que o navegador do cliente acessa o link, ele é redirecionado para o slot de produção. Cada solicitação subsequente tem o `x-ms-routing-name=self` cookie que fixa a sessão ao slot de produção.
+A query string `x-ms-routing-name=self` especifica o slot de produção. Depois que o navegador do cliente acessa o link, ele é redirecionado para o slot de produção. Cada requisição subsequente terá o cookie `x-ms-routing-name=self` que fixa a sessão ao slot de produção.
 
-Para permitir que os usuários aceitem seu aplicativo beta, defina o mesmo parâmetro de consulta como o nome do slot de não produção. Veja um exemplo:
+Para permitir que os usuários optem por seu aplicativo beta, defina o mesmo parâmetro de query string para o nome do slot não produtivo. Veja um exemplo:
 
 ```
-<webappname>.azurewebsites.net/?x-ms-routing-name=staging
+<nomedoaplicativoweb>.azurewebsites.net/?x-ms-routing-name=staging
 ```
 
-Por padrão, novos slots recebem uma regra de roteamento `0%` , mostrada em cinza. Quando você define esse valor explicitamente como `0%` (mostrado em texto preto), os usuários podem acessar o slot de preparo manualmente usando o `x-ms-routing-name` parâmetro de consulta. Mas eles não serão roteados para o slot automaticamente porque a porcentagem de roteamento é definida como 0. Esse é um cenário avançado em que você pode "Ocultar" o slot de preparo do público, permitindo que as equipes internas testem as alterações no slot.
+Por padrão, novos slots recebem a regra de roteamento `0%`, exibido em cinza. Quando você define esse valor explicitamente como `0%` (exibido em texto preto), seus usuários poderão acessar o slot de staging manualmente usando a query string `x-ms-routing-name`. Mas eles não serão roteados para o slot automaticamente porque a porcentagem de roteamento é definida como 0. Esse é um cenário avançado em que você pode "ocultar" o slot de staging do público, permitindo que as equipes internas testem as alterações no slot.
 
 <a name="Delete"></a>
 
 ## <a name="delete-a-slot"></a>Excluir um slot
 
-Pesquise e selecione seu aplicativo. Selecione **Deployment slots**  >  *\<slot to delete>*  >  **visão geral dos**slots de implantação. O tipo de aplicativo é mostrado como **serviço de aplicativo (slot)** para lembrá-lo de que você está exibindo um slot de implantação. Selecione **excluir** na barra de comandos.  
+Pesquise e selecione seu aplicativo. Selecione **Slots de implantação** > *\<slot para excluir>* > **Visão geral**. O tipo de aplicativo é exibido como **Serviço de Aplicativo (Slot)** para lembrá-lo de que você está visualizando um slot de implantação. Selecione **Excluir** na barra de comandos.
 
 ![Excluir um slot de implantação](./media/web-sites-staged-publishing/DeleteStagingSiteButton.png)
 
@@ -282,67 +282,67 @@ Pesquise e selecione seu aplicativo. Selecione **Deployment slots**  >  *\<slot 
 
 <a name="PowerShell"></a>
 
-## <a name="automate-with-powershell"></a>Automatizar com o PowerShell
+## <a name="automate-with-powershell"></a>Automatizar com PowerShell
 
 [!INCLUDE [updated-for-az](../../includes/updated-for-az.md)]
 
 O Azure PowerShell é um módulo que fornece cmdlets para gerenciar o Azure por meio do Windows PowerShell, incluindo suporte ao gerenciamento de slots de implantação no Serviço de Aplicativo do Azure.
 
-Para obter mais informações sobre como instalar e configurar o PowerShell do Azure, e como autenticar o PowerShell do Azure com sua assinatura do Azure, consulte [Como instalar e configurar o PowerShell do Microsoft Azure](/powershell/azure/).  
+Para obter mais informações sobre como instalar e configurar o PowerShell do Azure, e como autenticar o PowerShell do Azure com a sua assinatura do Azure, consulte [Como instalar e configurar o PowerShell do Microsoft Azure](/powershell/azure/).  
 
 ---
 ### <a name="create-a-web-app"></a>Criar um aplicativo Web
 ```powershell
-New-AzWebApp -ResourceGroupName [resource group name] -Name [app name] -Location [location] -AppServicePlan [app service plan name]
+New-AzWebApp -ResourceGroupName [nome do grupo de recursos] -Name [nome do aplicativo] -Location [região] -AppServicePlan [nome do plano do serviço de aplicativo]
 ```
 
 ---
 ### <a name="create-a-slot"></a>Criar um slot
 ```powershell
-New-AzWebAppSlot -ResourceGroupName [resource group name] -Name [app name] -Slot [deployment slot name] -AppServicePlan [app service plan name]
+New-AzWebAppSlot -ResourceGroupName [nome do grupo de recursos] -Name [nome do aplicativo] -Slot [deployment slot name] -AppServicePlan [nome do plano do serviço de aplicativo]
 ```
 
 ---
 ### <a name="initiate-a-swap-with-a-preview-multi-phase-swap-and-apply-destination-slot-configuration-to-the-source-slot"></a>Iniciar uma troca com uma visualização (troca de várias fases) e aplicar a configuração do slot de destino ao slot de origem
 ```powershell
 $ParametersObject = @{targetSlot  = "[slot name – e.g. "production"]"}
-Invoke-AzResourceAction -ResourceGroupName [resource group name] -ResourceType Microsoft.Web/sites/slots -ResourceName [app name]/[slot name] -Action applySlotConfig -Parameters $ParametersObject -ApiVersion 2015-07-01
+Invoke-AzResourceAction -ResourceGroupName [nome do grupo de recursos] -ResourceType Microsoft.Web/sites/slots -ResourceName [nome do aplicativo]/[nome do slot] -Action applySlotConfig -Parameters $ParametersObject -ApiVersion 2015-07-01
 ```
 
 ---
-### <a name="cancel-a-pending-swap-swap-with-review-and-restore-the-source-slot-configuration"></a>Cancelar uma permuta pendente (trocar com revisão) e restaurar a configuração do slot de origem
+### <a name="cancel-a-pending-swap-swap-with-review-and-restore-the-source-slot-configuration"></a>Cancelar um swap pendente (troca com pré-visualização) e restaurar a configuração do slot de origem
 ```powershell
-Invoke-AzResourceAction -ResourceGroupName [resource group name] -ResourceType Microsoft.Web/sites/slots -ResourceName [app name]/[slot name] -Action resetSlotConfig -ApiVersion 2015-07-01
+Invoke-AzResourceAction -ResourceGroupName [nome do grupo de recursos] -ResourceType Microsoft.Web/sites/slots -ResourceName [nome do aplicativo]/[nome do slot] -Action resetSlotConfig -ApiVersion 2015-07-01
 ```
 
 ---
-### <a name="swap-deployment-slots"></a>Permute slots de implantação
+### <a name="swap-deployment-slots"></a>Alternar slots de implantação
 ```powershell
 $ParametersObject = @{targetSlot  = "[slot name – e.g. "production"]"}
-Invoke-AzResourceAction -ResourceGroupName [resource group name] -ResourceType Microsoft.Web/sites/slots -ResourceName [app name]/[slot name] -Action slotsswap -Parameters $ParametersObject -ApiVersion 2015-07-01
+Invoke-AzResourceAction -ResourceGroupName [nome do grupo de recursos] -ResourceType Microsoft.Web/sites/slots -ResourceName [nome do aplicativo]/[nome do slot] -Action slotsswap -Parameters $ParametersObject -ApiVersion 2015-07-01
 ```
 
-### <a name="monitor-swap-events-in-the-activity-log"></a>Monitorar eventos de permuta no log de atividades
+### <a name="monitor-swap-events-in-the-activity-log"></a>Monitorar eventos de swap no log de atividades
 ```powershell
-Get-AzLog -ResourceGroup [resource group name] -StartTime 2018-03-07 -Caller SlotSwapJobProcessor  
+Get-AzLog -ResourceGroup [nome do grupo de recursos] -StartTime 2018-03-07 -Caller SlotSwapJobProcessor  
 ```
 
 ---
 ### <a name="delete-a-slot"></a>Excluir um slot
 ```powershell
-Remove-AzResource -ResourceGroupName [resource group name] -ResourceType Microsoft.Web/sites/slots –Name [app name]/[slot name] -ApiVersion 2015-07-01
+Remove-AzResource -ResourceGroupName [nome do grupo de recursos] -ResourceType Microsoft.Web/sites/slots –Name [nome do aplicativo]/[nome do slot] -ApiVersion 2015-07-01
 ```
 
-## <a name="automate-with-resource-manager-templates"></a>Automatizar com modelos do Resource Manager
+## <a name="automate-with-resource-manager-templates"></a>Automatizar com templates do Resource Manager
 
-Os [modelos de Azure Resource Manager](../azure-resource-manager/templates/overview.md) são arquivos JSON declarativos usados para automatizar a implantação e a configuração de recursos do Azure. Para trocar os slots usando modelos do Resource Manager, você definirá duas propriedades nos recursos *Microsoft. Web/sites/Slots* e *Microsoft. Web/sites* :
+Os [templates do Azure Resource Manager](../azure-resource-manager/templates/overview.md) são arquivos JSON declarativos usados para automatizar a implantação e a configuração de recursos no Azure. Para trocar slots usando templates do Resource Manager, você irá definir duas propriedades nos recursos *Microsoft.Web/sites/slots* e *Microsoft.Web/sites*:
 
-- `buildVersion`: essa é uma propriedade de cadeia de caracteres que representa a versão atual do aplicativo implantado no slot. Por exemplo: "v1", "1.0.0.1" ou "2019-09-20T11:53:25.2887393-07:00".
-- `targetBuildVersion`: essa é uma propriedade de cadeia de caracteres que especifica o que `buildVersion` o slot deve ter. Se o targetBuildVersion não for igual ao atual `buildVersion` , isso disparará a operação de permuta localizando o slot que tem o especificado `buildVersion` .
+- `buildVersion`: essa é uma propriedade do tipo string que representa a versão atual do aplicativo implantado no slot. Por exemplo: "v1", "1.0.0.1" ou "2019-09-20T11:53:25.2887393-07:00".
+- `targetBuildVersion`: essa é uma propriedade do tipo string que especifica qual `buildVersion` o slot deve possuir. Se o targetBuildVersion não for igual ao atual `buildVersion`, então isso irá dispar a operação de swap localizando o slot que tem o `buildVersion` que foi especificado.
 
-### <a name="example-resource-manager-template"></a>Exemplo de modelo do Resource Manager
+### <a name="example-resource-manager-template"></a>Exemplo de template do Resource Manager
 
-O modelo do Resource Manager a seguir atualizará o `buildVersion` slot de preparo e definirá o `targetBuildVersion` no slot de produção. Isso mudará os dois slots. O modelo pressupõe que você já tenha um webapp criado com um slot chamado "preparo".
+O template do Resource Manager a seguir atualizará o `buildVersion` do slot de staging e definirá o `targetBuildVersion` no slot de produção. Isso trocará os dois slots. O template pressupõe que você já tenha uma webapp criada com um slot chamado "staging".
 
 ```json
 {
@@ -386,7 +386,7 @@ O modelo do Resource Manager a seguir atualizará o `buildVersion` slot de prepa
 }
 ```
 
-Esse modelo do Resource Manager é idempotente, o que significa que ele pode ser executado repetidamente e produzir o mesmo estado dos slots. Após a primeira execução, o `targetBuildVersion` corresponderá ao atual `buildVersion` , de modo que uma troca não será disparada.
+Esse template do Resource Manager é idempotente, o que significa que ele pode ser executado repetidamente e produzir o mesmo estado dos slots. Após a primeira execução, o `targetBuildVersion` corresponderá ao atual `buildVersion`, de modo que uma troca não será disparada.
 
 <!-- ======== Azure CLI =========== -->
 
@@ -394,19 +394,19 @@ Esse modelo do Resource Manager é idempotente, o que significa que ele pode ser
 
 ## <a name="automate-with-the-cli"></a>Automatizar com a CLI
 
-Para obter os comandos da [CLI do Azure](https://github.com/Azure/azure-cli) para slots de implantação, confira [Slot de implantação do az webapp](/cli/azure/webapp/deployment/slot).
+Para mais informações sobre comandos da [CLI do Azure](https://github.com/Azure/azure-cli) para slots de implantação, confira [az webapp deployment slot](/cli/azure/webapp/deployment/slot).
 
-## <a name="troubleshoot-swaps"></a>Solucionar problemas de trocas
+## <a name="troubleshoot-swaps"></a>Solucionar problemas com swaps
 
-Se ocorrer algum erro durante uma [troca de slot](#AboutConfiguration), ele será registrado *D:\home\LogFiles\eventlog.xml*. Ele também é registrado no log de erros específico do aplicativo.
+Se ocorrer algum erro durante uma [troca de slot](#AboutConfiguration), ele será registrado em *D:\home\LogFiles\eventlog.xml*. Ele também será registrado no log de erros específico do aplicativo.
 
-Aqui estão alguns erros de permuta comuns:
+Aqui estão alguns erros de swap comuns:
 
-- Uma solicitação HTTP para a raiz do aplicativo é cronometrada. A operação de permuta aguarda por 90 segundos para cada solicitação HTTP e tenta novamente até 5 vezes. Se todas as novas tentativas atingirem o tempo limite, a operação de permuta será interrompida.
+- Uma requisição HTTP para a raiz do aplicativo é cronometrada. A operação de swap aguarda por 90 segundos cada requisição HTTP e tenta novamente até 5 vezes. Se todas as tentativas atingirem o tempo limite, a operação de troca será interrompida.
 
-- A inicialização do cache local poderá falhar quando o conteúdo do aplicativo exceder a cota de disco local especificada para o cache local. Para obter mais informações, consulte [visão geral do cache local](overview-local-cache.md).
+- A inicialização do cache local poderá falhar quando o conteúdo do aplicativo exceder a cota de disco local especificada para o cache local. Para obter mais informações, consulte [Visão geral do cache local](overview-local-cache.md).
 
-- Durante o [aquecimento personalizado](#Warm-up), as solicitações HTTP são feitas internamente (sem passar pela URL externa). Eles podem falhar com determinadas regras de regravação de URL no *Web.config*. Por exemplo, regras para redirecionar nomes de domínio ou impor HTTPS podem impedir que solicitações de aquecimento atinjam o código do aplicativo. Para contornar esse problema, modifique suas regras de reescrita adicionando as duas condições a seguir:
+- Durante o [aquecimento personalizado](#Warm-up), as requisições HTTP são feitas internamente (sem passar pela URL externa). Elas podem falhar com determinadas regras de rewrite de URL no *Web.config*. Por exemplo, regras para redirecionar nomes de domínio ou impor HTTPS podem impedir que requisições de aquecimento atinjam o código do aplicativo. Para contornar esse problema, modifique suas regras de rewrite adicionando as duas condições a seguir:
 
     ```xml
     <conditions>
@@ -415,7 +415,7 @@ Aqui estão alguns erros de permuta comuns:
       ...
     </conditions>
     ```
-- Sem um aquecimento personalizado, as regras de regravação de URL ainda podem bloquear solicitações HTTP. Para contornar esse problema, modifique suas regras de reescrita adicionando a seguinte condição:
+- Sem um aquecimento personalizado, as regras de rewrite de URL ainda podem bloquear requisições HTTP. Para contornar esse problema, modifique suas regras de rewrite adicionando a seguinte condição:
 
     ```xml
     <conditions>
@@ -424,7 +424,7 @@ Aqui estão alguns erros de permuta comuns:
     </conditions>
     ```
 
-- Após trocas de slot, o aplicativo pode experimentar reinicializações inesperadas. Isso ocorre porque, após uma troca, a configuração de associação de nome de host fica fora de sincronia, o que por si só não causa reinicializações. No entanto, determinados eventos de armazenamento subjacentes (como failovers de volume de armazenamento) podem detectar essas discrepâncias e forçar a reinicialização de todos os processos de trabalho. Para minimizar esses tipos de reinicializações, defina a [ `WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG=1` configuração do aplicativo](https://github.com/projectkudu/kudu/wiki/Configurable-settings#disable-the-generation-of-bindings-in-applicationhostconfig) em *todos os slots*. No entanto, essa configuração de aplicativo *não funciona com* aplicativos Windows Communication Foundation (WCF).
+- Após trocas de slot, o aplicativo pode passar por reinicializações inesperadas. Isso ocorre porque, após um swap, a configuração de associação de nome de host fica fora de sincronia, o que por si só não causa reinicializações. No entanto, determinados eventos subjacentes de armazenamento (como failovers de volume de armazenamento) podem detectar essas discrepâncias e forçar a reinicialização de todos os worker processes. Para minimizar esses tipos de reinicializações, defina a [configuração de aplicativo `WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG=1`](https://github.com/projectkudu/kudu/wiki/Configurable-settings#disable-the-generation-of-bindings-in-applicationhostconfig) em *todos os slots*. No entanto, essa configuração de aplicativo *não funciona* com aplicativos Windows Communication Foundation (WCF).
 
 ## <a name="next-steps"></a>Próximas etapas
-[Bloquear o acesso aos slots de não produção](app-service-ip-restrictions.md)
+[Bloquear o acesso aos slots não produtivo](app-service-ip-restrictions.md)

--- a/includes/app-service-deployment-slots-settings.md
+++ b/includes/app-service-deployment-slots-settings.md
@@ -11,34 +11,34 @@ ms.contentlocale: pt-BR
 ms.lasthandoff: 10/09/2020
 ms.locfileid: "82132145"
 ---
-Quando você clona a configuração de outro slot de implantação, a configuração clonada é editável. Alguns elementos de configuração seguem o conteúdo em uma permuta (não específico do slot), enquanto outros elementos de configuração permanecem no mesmo slot após uma permuta (específica do slot). A lista a seguir mostra as configurações que serão alterada com a troca de slots.
+Quando você clona a configuração de outro slot de implantação, a configuração clonada é editável. Alguns elementos de configuração acompanham o conteúdo quando acontece um swap (que não seja específico do slot), enquanto outros elementos de configuração permanecem no mesmo slot após um swap (específico do slot). As listas a seguir mostram as configurações que são alteradas com a troca de slots.
 
-**Configurações que são permutadas**:
+**Configurações que são trocadas**:
 
-* Configurações gerais, como versão do Framework, 32/64 bits, Web Sockets
-* Configurações do aplicativo (podem ser configuradas para fixarem-se a um slot)
-* Cadeias de conexão (podem ser configuradas para fixarem-se a um slot)
-* Mapeamentos de manipulador
+* Configurações gerais, como versão do framework, 32/64 bits, web sockets
+* Configurações de aplicativo (podem ser configuradas para se fixarem a um slot)
+* Strings de conexão (podem ser configuradas para se fixarem a um slot)
+* Mapeamentos de manipuladores
 * Certificados públicos
-* Conteúdo de Trabalhos Web
+* Conteúdo do WebJobs
 * Conexões híbridas *
-* Integração de rede virtual *
-* Pontos de extremidade de serviço *
+* Integração com rede virtual *
+* Endpoints do serviço *
 * Rede de distribuição de conteúdo do Azure *
 
-Os recursos marcados com um asterisco (*) estão planejados para serem desalternados. 
+Recursos marcados com um asterisco (*) estão planejados para que não sejam alternados.
 
 **Configurações que não são alternadas**:
 
-* Pontos de extremidade de publicação
+* Endpoints de publicação
 * Nomes de domínio personalizados
 * Certificados não públicos e configurações de TLS/SSL
 * Configurações de dimensionamento
-* Agendadores de Trabalhos Web
+* Agendadores de WebJobs
 * Restrições de IP
 * Always On
 * Configurações de Diagnóstico
-* CORS (compartilhamento de recursos entre origens)
+* CORS (Cross-origin resource sharing)
 
 > [!NOTE]
 > Determinadas configurações de aplicativo que se aplicam a configurações não alternadas também são trocadas. Por exemplo, como as configurações de diagnóstico não são trocadas, as configurações de aplicativo relacionadas, como `WEBSITE_HTTPLOGGING_RETENTION_DAYS` e `DIAGNOSTICS_AZUREBLOBRETENTIONDAYS` também não são trocadas, mesmo que não apareçam como configurações de slot.


### PR DESCRIPTION
This PR fixes some translation issues found on the pt-br version of the "[Set up staging environments in Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots)" article available at https://docs.microsoft.com/pt-br/azure/app-service/deploy-staging-slots
- Fixing “connection string” translation.
- Fixing “swap” translation.
- Fixing “request” translation.
- Fixing “query string” translation.
- Fixing “string” translation.
- Other minor translation fixes and improvements.