### PR TITLE
Update reference-connect-faq.md

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-faq.md
+++ b/articles/active-directory/hybrid/reference-connect-faq.md
@@ -121,7 +121,7 @@ Não.  Para permitir que Azure AD Connect crie automaticamente a conta do conect
 
 ## <a name="network"></a>Rede
 **P: Tenho um firewall, um dispositivo de rede ou outro item que limita o tempo que as conexões podem permanecer abertas na minha rede. O que meu limite de tempo limite do lado do cliente deve ser quando usa o Azure AD Connect?**  
-Todos os softwares de rede, dispositivos físicos ou qualquer outra coisa que limite o tempo máximo que as conexões podem permanecer abertas deve usar um limiar de pelo menos 300 minutos (300 segundos) para conectividade entre o servidor no qual o cliente do Azure AD Connect está instalado e o Active Directory do Azure. Esta recomendação também se aplica a todas as ferramentas de sincronização do Microsoft Identity lançadas anteriormente.
+Todos os softwares de rede, dispositivos físicos ou qualquer outra coisa que limite o tempo máximo que as conexões podem permanecer abertas deve usar um limiar de pelo menos 5 minutos (300 segundos) para conectividade entre o servidor no qual o cliente do Azure AD Connect está instalado e o Active Directory do Azure. Esta recomendação também se aplica a todas as ferramentas de sincronização do Microsoft Identity lançadas anteriormente.
 
 **P: Há suporte para SLDs (domínios de rótulo único)?**  
 Embora seja altamente não usar essa configuração de rede ([consulte o artigo](https://support.microsoft.com/help/2269810/microsoft-support-for-single-label-domains)), o uso da sincronização do Azure AD Connect com um único domínio de rótulo é compatível, desde que a configuração de rede para o domínio de nível único esteja funcionando corretamente.


### PR DESCRIPTION
Há um erro na descrição do tempo mínimo que o firewall deve manter a conexão sem antes desconectá-la, na linha 124.

No documento está descrito 300 minutos (300 segundos). 
O correto deve ser 5 minutos (300 segundos).

Informações úteis para fazer uma sugestão:
1. Acesse [Guias de início rápido de estilo para localização](https://docs.microsoft.com/globalization/localization/styleguides) para verificar as **10 principais e mais importantes regras** do Guia de Estilo da Microsoft.
2. Acesse [Portal de Idiomas da Microsoft](https://www.microsoft.com/language) para verificar a **tradução padronizada de termos** nos produtos da Microsoft.
